### PR TITLE
Keep player bar visible across screens

### DIFF
--- a/app/src/main/java/me/taplika/player/playback/MusicService.kt
+++ b/app/src/main/java/me/taplika/player/playback/MusicService.kt
@@ -114,8 +114,17 @@ class MusicService : android.app.Service() {
 
         fun pause() = player.pause()
         fun play() = player.play()
-        fun next() = player.seekToNextMediaItem()
-        fun previous() = player.seekToPreviousMediaItem()
+        fun next() {
+            if (player.hasNextMediaItem()) {
+                player.seekToNextMediaItem()
+            }
+        }
+
+        fun previous() {
+            if (player.hasPreviousMediaItem()) {
+                player.seekToPreviousMediaItem()
+            }
+        }
     }
 
     private inner class NotificationListener : PlayerNotificationManager.NotificationListener {

--- a/app/src/main/java/me/taplika/player/playback/MusicServiceConnection.kt
+++ b/app/src/main/java/me/taplika/player/playback/MusicServiceConnection.kt
@@ -96,6 +96,10 @@ class MusicServiceConnection(private val context: Context) {
                 _playerState.value = player.snapshot()
             }
 
+            override fun onPlaybackStateChanged(playbackState: Int) {
+                _playerState.value = player.snapshot()
+            }
+
             override fun onMediaMetadataChanged(mediaMetadata: MediaMetadata) {
                 _playerState.value = player.snapshot()
             }
@@ -112,6 +116,7 @@ class MusicServiceConnection(private val context: Context) {
     private fun ExoPlayer.snapshot(): PlayerUiState = PlayerUiState(
         isConnected = true,
         isPlaying = isPlaying,
+        isBuffering = playbackState == Player.STATE_BUFFERING,
         title = mediaMetadata.title?.toString(),
         artist = mediaMetadata.artist?.toString(),
         artworkUri = mediaMetadata.artworkUri
@@ -120,6 +125,7 @@ class MusicServiceConnection(private val context: Context) {
     data class PlayerUiState(
         val isConnected: Boolean = false,
         val isPlaying: Boolean = false,
+        val isBuffering: Boolean = false,
         val title: String? = null,
         val artist: String? = null,
         val artworkUri: Any? = null

--- a/app/src/main/java/me/taplika/player/ui/MainActivity.kt
+++ b/app/src/main/java/me/taplika/player/ui/MainActivity.kt
@@ -61,6 +61,14 @@ fun MusicPlayerRoot(viewModel: MainViewModel) {
         }
     }
 
+    val onPlayPauseAction = {
+        if (playerState.isConnected && playerState.isPlaying) {
+            viewModel.pause()
+        } else {
+            viewModel.play()
+        }
+    }
+
     NavHost(navController = navController, startDestination = "home") {
         composable("home") {
             HomeScreen(
@@ -88,9 +96,7 @@ fun MusicPlayerRoot(viewModel: MainViewModel) {
                     playlistPickerVisible = true
                 },
                 onToggleRepeat = { viewModel.toggleRepeatMode() },
-                onPlayPause = {
-                    if (playerState.isConnected && playerState.isPlaying) viewModel.pause() else viewModel.play()
-                },
+                onPlayPause = onPlayPauseAction,
                 onNext = { viewModel.next() },
                 onPrevious = { viewModel.previous() },
                 onImportLocal = { pickAudioLauncher.launch(arrayOf("audio/*")) }
@@ -105,6 +111,13 @@ fun MusicPlayerRoot(viewModel: MainViewModel) {
             PlaylistScreen(
                 playlist = playlists.firstOrNull { it.playlistId == playlistId },
                 songs = songs,
+                playlists = playlists,
+                repeatMode = repeatMode,
+                playerState = playerState,
+                onToggleRepeat = { viewModel.toggleRepeatMode() },
+                onPlayPause = onPlayPauseAction,
+                onNext = { viewModel.next() },
+                onPrevious = { viewModel.previous() },
                 onBack = { navController.popBackStack() },
                 onPlaySong = { songId -> playlistId?.let { viewModel.playSongFromPlaylist(it, songId) } },
                 onRemoveSong = { songId -> playlistId?.let { viewModel.removeSongFromPlaylist(it, songId) } },
@@ -112,8 +125,7 @@ fun MusicPlayerRoot(viewModel: MainViewModel) {
                     playlistId?.let { currentId ->
                         viewModel.moveSongToPlaylist(song, target, currentId)
                     }
-                },
-                playlists = playlists
+                }
             )
         }
     }

--- a/app/src/main/java/me/taplika/player/ui/screens/PlaylistScreen.kt
+++ b/app/src/main/java/me/taplika/player/ui/screens/PlaylistScreen.kt
@@ -31,6 +31,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import me.taplika.player.data.PlaylistEntity
 import me.taplika.player.data.SongWithPosition
+import me.taplika.player.playback.MusicServiceConnection.PlayerUiState
+import me.taplika.player.playback.RepeatMode
+import me.taplika.player.ui.widgets.PlayerBar
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -38,6 +41,12 @@ fun PlaylistScreen(
     playlist: PlaylistEntity?,
     songs: List<SongWithPosition>,
     playlists: List<PlaylistEntity>,
+    repeatMode: RepeatMode,
+    playerState: PlayerUiState,
+    onToggleRepeat: () -> Unit,
+    onPlayPause: () -> Unit,
+    onNext: () -> Unit,
+    onPrevious: () -> Unit,
     onBack: () -> Unit,
     onPlaySong: (Long) -> Unit,
     onRemoveSong: (Long) -> Unit,
@@ -52,6 +61,16 @@ fun PlaylistScreen(
                         Icon(imageVector = Icons.Default.ArrowBack, contentDescription = "Back")
                     }
                 }
+            )
+        },
+        bottomBar = {
+            PlayerBar(
+                playerState = playerState,
+                repeatMode = repeatMode,
+                onPlayPause = onPlayPause,
+                onNext = onNext,
+                onPrevious = onPrevious,
+                onToggleRepeat = onToggleRepeat
             )
         }
     ) { padding ->

--- a/app/src/main/java/me/taplika/player/ui/widgets/PlayerBar.kt
+++ b/app/src/main/java/me/taplika/player/ui/widgets/PlayerBar.kt
@@ -51,7 +51,7 @@ fun PlayerBar(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp, vertical = 12.dp),
-            verticalAlignment = Alignment.CenterVertically,
+            verticalAlignment = Alignment.Top,
             horizontalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             AsyncImage(

--- a/app/src/main/java/me/taplika/player/ui/widgets/PlayerBar.kt
+++ b/app/src/main/java/me/taplika/player/ui/widgets/PlayerBar.kt
@@ -1,8 +1,10 @@
 package me.taplika.player.ui.widgets
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -13,6 +15,7 @@ import androidx.compose.material.icons.outlined.Pause
 import androidx.compose.material.icons.outlined.PlayArrow
 import androidx.compose.material.icons.outlined.Repeat
 import androidx.compose.material.icons.outlined.RepeatOn
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -21,7 +24,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import me.taplika.player.playback.RepeatMode
@@ -39,6 +44,7 @@ fun PlayerBar(
     if (!playerState.isConnected) return
     Surface(
         tonalElevation = 4.dp,
+        shape = MaterialTheme.shapes.extraLarge,
         modifier = Modifier.fillMaxWidth()
     ) {
         Row(
@@ -51,23 +57,47 @@ fun PlayerBar(
             AsyncImage(
                 model = playerState.artworkUri ?: me.taplika.player.R.drawable.ic_stat_music_note,
                 contentDescription = playerState.title,
-                modifier = Modifier.size(56.dp),
+                modifier = Modifier
+                    .size(56.dp)
+                    .clip(MaterialTheme.shapes.small),
                 contentScale = ContentScale.Crop
             )
-            ColumnInfo(title = playerState.title, artist = playerState.artist)
-            IconButton(onClick = onPrevious) {
-                Icon(imageVector = Icons.Filled.SkipPrevious, contentDescription = "Previous")
-            }
-            IconButton(onClick = onPlayPause) {
-                val icon = if (playerState.isPlaying) Icons.Outlined.Pause else Icons.Outlined.PlayArrow
-                Icon(imageVector = icon, contentDescription = "Play or pause")
-            }
-            IconButton(onClick = onNext) {
-                Icon(imageVector = Icons.Filled.SkipNext, contentDescription = "Next")
-            }
-            IconButton(onClick = onToggleRepeat) {
-                val icon = if (repeatMode == RepeatMode.REPEAT_ALL) Icons.Outlined.RepeatOn else Icons.Outlined.Repeat
-                Icon(imageVector = icon, contentDescription = "Toggle repeat")
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                ColumnInfo(title = playerState.title, artist = playerState.artist)
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    IconButton(onClick = onPrevious, modifier = Modifier.size(48.dp)) {
+                        Icon(imageVector = Icons.Filled.SkipPrevious, contentDescription = "Previous")
+                    }
+                    Box(
+                        modifier = Modifier.size(48.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        if (playerState.isBuffering) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(24.dp),
+                                strokeWidth = 2.dp
+                            )
+                        } else {
+                            IconButton(onClick = onPlayPause, modifier = Modifier.fillMaxSize()) {
+                                val icon = if (playerState.isPlaying) Icons.Outlined.Pause else Icons.Outlined.PlayArrow
+                                Icon(imageVector = icon, contentDescription = "Play or pause")
+                            }
+                        }
+                    }
+                    IconButton(onClick = onNext, modifier = Modifier.size(48.dp)) {
+                        Icon(imageVector = Icons.Filled.SkipNext, contentDescription = "Next")
+                    }
+                    IconButton(onClick = onToggleRepeat, modifier = Modifier.size(48.dp)) {
+                        val icon = if (repeatMode == RepeatMode.REPEAT_ALL) Icons.Outlined.RepeatOn else Icons.Outlined.Repeat
+                        Icon(imageVector = icon, contentDescription = "Toggle repeat")
+                    }
+                }
             }
         }
     }
@@ -75,10 +105,20 @@ fun PlayerBar(
 
 @Composable
 private fun ColumnInfo(title: String?, artist: String?) {
-    Column() {
-        Text(text = title ?: "", style = MaterialTheme.typography.bodyLarge, maxLines = 1)
+    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        Text(
+            text = title ?: "",
+            style = MaterialTheme.typography.bodyLarge,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
         if (!artist.isNullOrBlank()) {
-            Text(text = artist, style = MaterialTheme.typography.bodySmall, maxLines = 1)
+            Text(
+                text = artist,
+                style = MaterialTheme.typography.bodySmall,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary
- keep the player bar visible when navigating to playlists and share play/pause handling
- restyle the player bar with rounded corners, stacked controls, and ellipsized text while showing buffering feedback
- expose playback buffering state from the service so the UI can show a loading indicator

## Testing
- ./gradlew test *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d7f7e25b388324b495b32c80c419f6