### PR TITLE
Update player state when queueing songs

### DIFF
--- a/app/src/main/java/me/taplika/player/playback/MusicService.kt
+++ b/app/src/main/java/me/taplika/player/playback/MusicService.kt
@@ -15,6 +15,7 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.ui.PlayerNotificationManager
 import me.taplika.player.R
 import me.taplika.player.ui.MainActivity
@@ -32,7 +33,11 @@ class MusicService : android.app.Service() {
 
     override fun onCreate() {
         super.onCreate()
-        player = ExoPlayer.Builder(this).build().apply {
+        val mediaSourceFactory = DefaultMediaSourceFactory(this)
+            .setDataSourceFactory(YoutubeResolvingDataSourceFactory(this))
+        player = ExoPlayer.Builder(this)
+            .setMediaSourceFactory(mediaSourceFactory)
+            .build().apply {
             setAudioAttributes(
                 AudioAttributes.Builder()
                     .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)

--- a/app/src/main/java/me/taplika/player/playback/MusicServiceConnection.kt
+++ b/app/src/main/java/me/taplika/player/playback/MusicServiceConnection.kt
@@ -62,6 +62,19 @@ class MusicServiceConnection(private val context: Context) {
 
     fun playQueue(items: List<PlayableMedia>, startIndex: Int, repeatMode: RepeatMode) {
         if (!isBound) bind()
+        val media = items.getOrNull(startIndex).takeIf { items.isNotEmpty() }
+            ?: items.firstOrNull()
+        if (media != null) {
+            val currentState = _playerState.value
+            _playerState.value = currentState.copy(
+                isConnected = true,
+                isPlaying = false,
+                isBuffering = true,
+                title = media.title,
+                artist = media.artist,
+                artworkUri = media.artworkUri
+            )
+        }
         controller?.playQueue(items, startIndex, repeatMode)
     }
 

--- a/app/src/main/java/me/taplika/player/playback/MusicServiceConnection.kt
+++ b/app/src/main/java/me/taplika/player/playback/MusicServiceConnection.kt
@@ -4,6 +4,7 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.ServiceConnection
+import android.net.Uri
 import android.os.IBinder
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -64,18 +65,24 @@ class MusicServiceConnection(private val context: Context) {
         if (!isBound) bind()
         val media = items.getOrNull(startIndex).takeIf { items.isNotEmpty() }
             ?: items.firstOrNull()
-        if (media != null) {
-            val currentState = _playerState.value
-            _playerState.value = currentState.copy(
-                isConnected = true,
-                isPlaying = false,
-                isBuffering = true,
-                title = media.title,
-                artist = media.artist,
-                artworkUri = media.artworkUri
-            )
+        media?.let {
+            previewPlayback(it.title, it.artist, it.artworkUri)
         }
         controller?.playQueue(items, startIndex, repeatMode)
+    }
+
+    fun previewPlayback(title: String?, artist: String?, artworkUri: String?) {
+        val currentState = _playerState.value
+        _playerState.value = currentState.copy(
+            isConnected = true,
+            isPlaying = false,
+            isBuffering = true,
+            title = title,
+            artist = artist,
+            artworkUri = artworkUri
+                ?.takeIf { it.isNotBlank() }
+                ?.let(Uri::parse)
+        )
     }
 
     fun setRepeatMode(repeatMode: RepeatMode) {

--- a/app/src/main/java/me/taplika/player/playback/YoutubeResolvingDataSourceFactory.kt
+++ b/app/src/main/java/me/taplika/player/playback/YoutubeResolvingDataSourceFactory.kt
@@ -1,0 +1,57 @@
+package me.taplika.player.playback
+
+import android.content.Context
+import android.net.Uri
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DataSpec
+import androidx.media3.datasource.DefaultDataSource
+import androidx.media3.datasource.DefaultHttpDataSource
+import androidx.media3.datasource.ResolvingDataSource
+import java.io.IOException
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.runBlocking
+import me.taplika.player.search.RemoteSongRepository
+
+class YoutubeResolvingDataSourceFactory(context: Context) : DataSource.Factory {
+    private val repository = RemoteSongRepository(context)
+    private val cache = ConcurrentHashMap<String, RemoteSongRepository.StreamResolution>()
+    private val baseFactory = DefaultDataSource.Factory(
+        context,
+        DefaultHttpDataSource.Factory()
+    )
+
+    override fun createDataSource(): DataSource {
+        val upstream = baseFactory.createDataSource()
+        return ResolvingDataSource(upstream, Resolver())
+    }
+
+    private inner class Resolver : ResolvingDataSource.Resolver {
+        override fun resolveDataSpec(dataSpec: DataSpec): DataSpec {
+            if (dataSpec.uri.scheme != YOUTUBE_SCHEME) {
+                return dataSpec
+            }
+
+            val rawId = dataSpec.uri.schemeSpecificPart ?: dataSpec.uri.lastPathSegment
+            val videoId = rawId?.removePrefix("//")?.takeIf { it.isNotBlank() }
+                ?: throw IOException("Missing YouTube video id")
+
+            val resolution = cache[videoId] ?: runBlocking {
+                repository.resolveYoutubeId(videoId)
+            }?.also { resolved ->
+                cache[videoId] = resolved
+            }
+
+            val streamUrl = resolution?.streamUrl
+                ?: throw IOException("Unable to resolve stream for video id: $videoId")
+
+            val resolvedUri = Uri.parse(streamUrl)
+            return dataSpec.buildUpon().setUri(resolvedUri).build()
+        }
+    }
+
+    companion object {
+        private const val YOUTUBE_SCHEME = "yt"
+
+        fun buildYoutubeUri(videoId: String): String = "$YOUTUBE_SCHEME:$videoId"
+    }
+}

--- a/app/src/main/java/me/taplika/player/ui/MainViewModel.kt
+++ b/app/src/main/java/me/taplika/player/ui/MainViewModel.kt
@@ -131,7 +131,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 results.any { it.videoId == song.videoId }
             } ?: listOf(song)
 
-            val queue = candidates.map(RemoteSong::toPlayableMedia)
+            val queue = candidates.map { it.toPlayableMedia() }
             if (queue.isEmpty()) return@launch
 
             val startIndex = candidates.indexOfFirst { it.videoId == song.videoId }

--- a/app/src/main/java/me/taplika/player/ui/MainViewModel.kt
+++ b/app/src/main/java/me/taplika/player/ui/MainViewModel.kt
@@ -122,6 +122,11 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     fun playRemoteSong(song: RemoteSong) {
+        musicConnection.previewPlayback(
+            title = song.title,
+            artist = song.artist,
+            artworkUri = song.thumbnailUrl
+        )
         viewModelScope.launch {
             val candidates = _searchResults.value.takeIf { results ->
                 results.any { it.videoId == song.videoId }
@@ -173,6 +178,12 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         viewModelScope.launch {
             val songs = libraryRepository.playlistSongs(playlistId).first()
             if (songs.isEmpty()) return@launch
+            val targetSong = songs.firstOrNull { it.songId == songId } ?: songs.first()
+            musicConnection.previewPlayback(
+                title = targetSong.title,
+                artist = targetSong.artist,
+                artworkUri = targetSong.artworkUri
+            )
             val playablePairs = withContext(Dispatchers.IO) {
                 songs.mapNotNull { song ->
                     val playable = when (song.sourceType) {


### PR DESCRIPTION
## Summary
- update the music service connection to emit the queued song information immediately
- mark the player UI as buffering while the service prepares playback

## Testing
- ./gradlew test --console=plain *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d80b4bc988832488e58cb5a40a7dbf